### PR TITLE
[Fix: settings.gradle] src 내의 폴더 모듈로 인식되는 이슈

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,7 @@ private void makeModules(final File moduleDir, final String parentDirNames = "")
 
 private static boolean isModuleDir(final File subModule) {
 
-    return subModule.listFiles().size() != 0 && !subModule.list().contains("build.gradle")
+    return subModule.listFiles().size() != 0 && !subModule.list().contains("src")
 }
 
 private void makeBuildGradleFile(final File subModule) {


### PR DESCRIPTION
- 한 번씩 모듈 인식이 잘못되어 src 내의 폴더가 모듈로 되는 이슈 발생
- 이는 buidl.gradle 파일이 로드 되기 전 인텔리제이가 파일을 인덱스 스캔을 하기 때문으로 추정
- `settings.gradle` 로직 중 모듈 인식 조건을 `build.gradle` -> `src`로 변경 조치